### PR TITLE
chore(tsconfig): add tsconfigs

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "module": "amd",
+    "moduleResolution": "node",
+    "lib": [
+      "es2017",
+      "dom"
+    ],
+    "outDir": "dist/amd",
+    "strict": true,
+    "noImplicitReturns": true,
+    "forceConsistentCasingInFileNames": true,
+    "experimentalDecorators": true
+  }
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -9,7 +9,10 @@
     ],
     "outDir": "dist/amd",
     "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
     "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
     "forceConsistentCasingInFileNames": true,
     "experimentalDecorators": true
   }

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,19 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "declaration": true,
+    "stripInternal": true
+  },
+  "exclude": [
+    "the 'exclude' is here only for reference,",
+    "since the patterns will be resolved relative to the file they are in."
+  ],
+  "exclude": [
+    ".vscode",
+    "dist",
+    "doc",
+    "node_modules",
+    "test",
+    "packages"
+  ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist/test"
+  },
+  "exclude": [
+    "the 'exclude' is here only for reference,",
+    "since the patterns will be resolved relative to the file they are in."
+  ],
+  "exclude": [
+    ".vscode",
+    "dist",
+    "doc",
+    "node_modules"
+  ]
+}


### PR DESCRIPTION
This is based on the configs of `aurelia-validation`, `aurelia-dialog`, `aurelia-ux`.
1. I skipped `noUnusedLocals`, `noUnusedParameters` - I would leave this to the linter
2. We were already using the majority of the *strict* settings so I just added `strict: true`. We should be cautious with this though since new flags can be added with new TS versions.
3. The only problem that popped up when I applied it to `aurelia-dialog` was related to the `noImplicitThis` setting - in a `PropertyDescriptor` get/set needed explicit `this` typing.
4. Every inheriting project will have to add its `exclude`, `include`, ... - the patterns are resolved relative to the file they are declared. Did add a *reference* `exclude`s - if the *hackish comment* in the `.json`s is too much or will result in some problems I'll remove it.